### PR TITLE
Failure on partials in apply_transformation

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -265,7 +265,7 @@ def align_reconstructions(reconstruction_shots,
 
 
 def apply_transformations(transformations):
-    submodels = itertools.groupby(transformations.keys(), lambda key: key.submodel_path)
+    submodels = itertools.groupby(sorted(transformations.keys(), key=lambda key: key.submodel_path), lambda key: key.submodel_path)
     for submodel_path, keys in submodels:
         data = dataset.DataSet(submodel_path)
         if not data.reconstruction_exists():


### PR DESCRIPTION
groupby expects its input in a sorted order. When this is not true, multiple calls to data.load_reconstruction for a single submodel will result in applied similarity transforms being lost.
This proposed change resolves the issue by providing a sorted list to groupby.