### PR TITLE
Update to work on ppc64le

### DIFF
--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -68,7 +68,7 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
 
   const T eps = T(1e-30);
   const T det = A.determinant();
-  if (abs(det) < eps) {
+  if ((det < eps) && (det > -eps)) {
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;


### PR DESCRIPTION
Since on POWER the input of abs() is promoted to an integer (or the result is), this condition always holds. This is a fix that hopefully makes it work on ppc64le, this was verified to work on ppc64le and returns valid results.

I've filed a [concurrent pull request](https://github.com/mapillary/OpenSfM/pull/761) for OpenSfM itself, but it seems like they certainly do take their time...