### PR TITLE
Update fpdf2 to a more recent version so it doesn't conflict with Pillow 8.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle==0.4.0
 exifread==2.1.2
 flask==1.1.2
-fpdf2==2.1.0
+fpdf2==2.2.0
 joblib==0.14.1
 matplotlib
 networkx==1.11


### PR DESCRIPTION
fpdf2 2.1.0 relies on Pillow <= 8.0.0. This change moves fpdf forward one minor version so that `pip install requirements.txt` can finish. 

Given 2.1.0 has been yanked (I believe due to a security concern with Pillow <8.1.1). 

I have not fully tested all workflows, it's _plausible_ that if we depend on .font python files things might break (based on https://github.com/PyFPDF/fpdf2/blob/master/CHANGELOG.md ) but this _should_ be a minimal change. 