### PR TITLE
Fix log for python3.6

### DIFF
--- a/opensfm/log.py
+++ b/opensfm/log.py
@@ -5,8 +5,7 @@ import vmem
 
 def setup() -> None:
     logging.basicConfig(
-        format="%(asctime)s %(levelname)s: %(message)s", level=logging.DEBUG, force=True
-    )
+        format="%(asctime)s %(levelname)s: %(message)s", level=logging.DEBUG)
 
 
 def memory_usage() -> float:


### PR DESCRIPTION
[#12](https://github.com/OpenDroneMap/OpenSfM/issues/12)
There isn't the key `force` the logging module in python3.6 yet. So, when we use this opensfm version in python3.6, it will raise an error. So, I remove `, force=True` in `opensfm/log.py`, then that error disappears.