### PR TITLE
export_visualsfm: Small refactor to speed up the operation

### DIFF
--- a/opensfm/actions/export_visualsfm.py
+++ b/opensfm/actions/export_visualsfm.py
@@ -77,11 +77,11 @@ def export(
         skipped_points = 0
         lines.append("")
         points = reconstruction.points
+        shots_keys = list(reconstruction.shots.keys())
         lines.append(str(len(points)))
         points_count_index = len(lines) - 1
 
         for point_id, point in points.items():
-            shots = reconstruction.shots
             coord = point.coordinates
             color = list(map(int, point.color))
 
@@ -92,7 +92,7 @@ def export(
                 if export_only is not None and shot_key not in export_only:
                     continue
 
-                if shot_key in shots.keys():
+                if shot_key in shots_keys:
                     v = obs.point
                     x = (0.5 + v[0]) * shot_size_cache[shot_key][1]
                     y = (0.5 + v[1]) * shot_size_cache[shot_key][0]


### PR DESCRIPTION
Move call of reconstruction.shots.keys() outside of the loop through all
points. This gives significant speed-up especially on large datasets.

For instance, I have got a 4 times speed boost at my dataset (1018152 points,
296 shots):

Before:
$ time /code/SuperBuild/install/bin/opensfm/bin/opensfm export_visualsfm \
 --points /var/www/data/f267df83-f8f8-4bf0-b2e1-41ae16c805e5/opensfm

real    8m46.180s
user    8m41.184s
sys     0m12.073s

After:
$ time /code/SuperBuild/install/bin/opensfm/bin/opensfm export_visualsfm \
 --points /var/www/data/f267df83-f8f8-4bf0-b2e1-41ae16c805e5/opensfm

real    2m10.472s
user    2m7.576s
sys     0m9.789s