### PR TITLE
log corrupted image file name in imread

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -1206,8 +1206,11 @@ def imread(
     if ext.lower() == ".tiff" or ext.lower() == ".tif":
         return imread_rasterio(path, grayscale, unchanged, anydepth)
     else:
-        with open(path, "rb") as fb:
-            return imread_from_fileobject(fb, grayscale, unchanged, anydepth)
+        try:
+            with open(path, "rb") as fb:
+                return imread_from_fileobject(fb, grayscale, unchanged, anydepth)
+        except IOError:
+            raise IOError("Unable to load image {}".format(path))
 
 
 def imread_from_fileobject(


### PR DESCRIPTION
Hi Piero,

This PR tries to log the image filename if there is a somewhat corrupted image, the same as the behavior for loading raster data. Due to parallel processing, it's hard to tell which exact image is corrupted from the current logs