### PR TITLE
Fix DSPSIFT color pick

### DIFF
--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -656,6 +656,8 @@ def extract_features(
 
     xs = points[:, 0].round().astype(int)
     ys = points[:, 1].round().astype(int)
+    xs = np.clip(xs, 0, image.shape[1] - 1)
+    ys = np.clip(ys, 0, image.shape[0] - 1)
     colors = image[ys, xs]
     if image.shape[2] == 1:
         colors = np.repeat(colors, 3).reshape((-1, 3))

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -656,8 +656,6 @@ def extract_features(
 
     xs = points[:, 0].round().astype(int)
     ys = points[:, 1].round().astype(int)
-    xs = np.clip(xs, 0, image.shape[1] - 1)
-    ys = np.clip(ys, 0, image.shape[0] - 1)
     colors = image[ys, xs]
     if image.shape[2] == 1:
         colors = np.repeat(colors, 3).reshape((-1, 3))

--- a/opensfm/src/features/dspsift.h
+++ b/opensfm/src/features/dspsift.h
@@ -6,6 +6,6 @@ namespace features {
 
 py::tuple dspsift(foundation::pyarray_f image, float peak_threshold,
                 float edge_threshold, int target_num_features,
-                bool feature_root, bool domain_size_pooling, bool estimate_affine_shape);
+                bool feature_root, bool domain_size_pooling, bool estimate_affine_shape, int border_size);
 
 }

--- a/opensfm/src/features/python/pybind.cc
+++ b/opensfm/src/features/python/pybind.cc
@@ -62,7 +62,8 @@ PYBIND11_MODULE(pyfeatures, m) {
         py::arg("target_num_features") = 0,
         py::arg("feature_root") = true,
         py::arg("domain_size_pooling") = true,
-        py::arg("estimate_affine_shape") = true);
+        py::arg("estimate_affine_shape") = true,
+        py::arg("border_size") = 5);
 
   m.def("match_using_words", features::match_using_words);
   m.def("compute_vlad_descriptor", features::compute_vlad_descriptor,


### PR DESCRIPTION
Hi, this PR tries to fix the issue for picking color of detected features. 

The previous update https://github.com/OpenDroneMap/OpenSfM/pull/33 seems to make it easier to detect features at the edge. For example, assuming an image sized 1000x1000, vlfeat can produce feature point at [500, 999.65], rounding this coordinate will lead to out of bounds error when picking color with it. 

I think this is related to pixel center, vlfeat might use (0.5, 0.5) as the center, maybe a better fix would be minus 0.5 before rounding? Not sure how other feature detectors deal with coordinates related pixel center, no such issue observed from other feature detectors.